### PR TITLE
Make "purge" greate again

### DIFF
--- a/src/green/sc/cyclic_vector_space_fock_sigma.h
+++ b/src/green/sc/cyclic_vector_space_fock_sigma.h
@@ -144,6 +144,7 @@ namespace green::opt {
      *  \param i
      * **/
     void add(const fock_sigma<S1, St>& Vec) {
+      if(_m_size == _diis_size) throw sc::sc_diis_vsp_error("VSpace is at it's maximum capacity");
       if(!utils::context.global_rank) write_to_dbase(_index, Vec);
       MPI_Barrier(utils::context.global);
       _m_size++;

--- a/src/green/sc/fock_sigma.h
+++ b/src/green/sc/fock_sigma.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024 University of Michigan
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the “Software”), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+ * PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+ * FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef GREEN_SC_FOCK_SIGMA_H
+#define GREEN_SC_FOCK_SIGMA_H
+
+#include <Eigen/Dense>
+
+#include "common_defs.h"
+#include "common_utils.h"
+
+namespace green::opt {
+
+  template <typename prec>
+  using MMatrixX = Eigen::Map<Eigen::Matrix<prec, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+
+  /**
+   *
+   * \brief fock_sigma
+   *
+   * The class provides a vector definition for combined Fock matrix and Self-energy.
+   *
+   */
+  template <typename S1, typename St>
+  class fock_sigma {
+  private:
+    S1 _m_Fock;
+    St _m_Sigma;
+
+  public:
+    fock_sigma() = default;
+    fock_sigma(const fock_sigma& rhs) :
+        _m_Fock(sc::internal::init_data(rhs._m_Fock)), _m_Sigma(sc::internal::init_data(rhs._m_Sigma)) {
+      sc::internal::assign(_m_Fock, rhs._m_Fock);
+      sc::internal::assign(_m_Sigma, rhs._m_Sigma);
+    }
+    fock_sigma(const S1& fock, const St& sigma) :
+        _m_Fock(sc::internal::init_data(fock)), _m_Sigma(sc::internal::init_data(sigma)) {
+      sc::internal::assign(_m_Fock, fock);
+      sc::internal::assign(_m_Sigma, sigma);
+    }
+
+    /**
+     * Assign Fock-Sigma pair
+     * @param rhs right-hand side
+     * @return updated Fock-Sigma pair
+     */
+    fock_sigma& operator=(const fock_sigma& rhs) {
+      sc::internal::assign(_m_Fock, rhs._m_Fock);
+      sc::internal::assign(_m_Sigma, rhs._m_Sigma);
+      return *this;
+    }
+
+    S1&  get_fock() { return _m_Fock; }
+    St&  get_sigma() { return _m_Sigma; }
+    void set_fock(S1& F_) { sc::internal::assign(_m_Fock, F_); }
+    void set_sigma(St& S_) { sc::internal::assign(_m_Sigma, S_); }
+    void set_fock_sigma(S1& F_, St& S_) {
+      set_fock(F_);
+      set_sigma(S_);
+    }
+    const S1&             get_fock() const { return _m_Fock; }
+    const St&             get_sigma() const { return _m_Sigma; }
+
+    std::complex<double>* get_fock_data() { return sc::internal::get_ref(_m_Fock); }
+    std::complex<double>* get_sigma_data() { return sc::internal::get_ref(_m_Sigma); }
+
+    void                  set_zero() {
+      sc::internal::set_zero(_m_Fock);
+      sc::internal::set_zero(_m_Sigma);
+    }
+
+    template <typename T>
+    fock_sigma operator*=(T c) {
+      using namespace sc::internal;
+      _m_Fock *= c;
+      _m_Sigma *= c;
+      return *this;
+    }
+
+    fock_sigma operator+=(const fock_sigma& vec) {
+      using namespace sc::internal;
+      _m_Fock += vec.get_fock();
+      _m_Sigma += vec.get_sigma();
+      return *this;
+    }
+
+    fock_sigma operator+=(fock_sigma&& vec) {
+      using namespace sc::internal;
+      _m_Fock += vec.get_fock();
+      _m_Sigma += vec.get_sigma();
+      return *this;
+    }
+  };
+
+  template <typename prec, typename = std::enable_if_t<std::is_same_v<prec, std::remove_const_t<prec>>>>
+  auto matrix(ndarray::ndarray<prec, 2>&& array) {
+    return MMatrixX<prec>(array.data(), array.shape()[0], array.shape()[1]);
+  }
+
+  template <typename T, typename C>
+  void add(T& res, const T& b, C c) {
+    res = b;
+    res *= c;
+  }
+
+  template <typename T, typename C>
+  void add(T& res, const T& a, const T& b, C c) {
+    res = b;
+    res *= c;
+    res += a;
+  }
+
+}  // namespace green::opt
+
+#endif  // GREEN_SC_FOCK_SIGMA_H

--- a/src/green/sc/mixing.h
+++ b/src/green/sc/mixing.h
@@ -151,9 +151,9 @@ namespace green::sc {
    */
   template <typename G, typename S1, typename St>
   class diis : public sigma_damping<G, S1, St> {
-    using vec_t       = opt::FockSigma<S1, St>;
+    using vec_t       = opt::fock_sigma<S1, St>;
     using problem_t   = opt::shared_optimization_problem<vec_t>;
-    using vec_space_t = opt::VSpaceFockSigma<S1, St>;
+    using vec_space_t = opt::vector_space_fock_sigma<S1, St>;
     using residual_t  = std::function<void(vec_space_t&, problem_t&, vec_t&)>;
 
   public:

--- a/src/green/sc/mixing.h
+++ b/src/green/sc/mixing.h
@@ -253,9 +253,6 @@ namespace green::sc {
         case CDIIS:
           _mixing = std::make_unique<diis<G, S1, St>>(p, true);
           break;
-        default:
-          _mixing = std::make_unique<no_mixing<G, S1, St>>();
-          break;
       }
     }
 

--- a/src/green/sc/residuals.h
+++ b/src/green/sc/residuals.h
@@ -29,6 +29,9 @@
 
 namespace green::opt {
 
+  using MMatrixXcd  = Eigen::Map<Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+  using CMMatrixXcd = Eigen::Map<const Eigen::Matrix<std::complex<double>, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>;
+
   template <typename vec_t>
   class shared_optimization_problem {
   private:
@@ -42,9 +45,9 @@ namespace green::opt {
   };
 
   template <>
-  class shared_optimization_problem<FockSigma<ztensor<4>, utils::shared_object<ztensor<5>>>> {
+  class shared_optimization_problem<fock_sigma<ztensor<4>, utils::shared_object<ztensor<5>>>> {
   private:
-    using vec_t = FockSigma<ztensor<4>, utils::shared_object<ztensor<5>>>;
+    using vec_t = fock_sigma<ztensor<4>, utils::shared_object<ztensor<5>>>;
     vec_t& _vec;
 
   public:
@@ -55,7 +58,7 @@ namespace green::opt {
   };
 
   template <typename G, typename S1, typename St>
-  void commutator_t(const grids::transformer_t& ft, St& C_t, G& G_t, FockSigma<S1, St>& FS_t, double mu, const S1& H,
+  void commutator_t(const grids::transformer_t& ft, St& C_t, G& G_t, fock_sigma<S1, St>& FS_t, double mu, const S1& H,
                     const S1& S) { /*do nothing, used for the test purpose*/
   }
 
@@ -125,7 +128,7 @@ namespace green::opt {
    */
   template <>
   void commutator_t(const grids::transformer_t& ft, utils::shared_object<ztensor<5>>& C_t, utils::shared_object<ztensor<5>>& G_t,
-                    FockSigma<ztensor<4>, utils::shared_object<ztensor<5>>>& FS_t, double mu, const ztensor<4>& H0,
+                    fock_sigma<ztensor<4>, utils::shared_object<ztensor<5>>>& FS_t, double mu, const ztensor<4>& H0,
                     const ztensor<4>& S) {
     auto& C_t_full = C_t.object();
     C_t.fence();
@@ -134,7 +137,7 @@ namespace green::opt {
   }
 
   template <>
-  void commutator_t(const grids::transformer_t& ft, ztensor<5>& C_t, ztensor<5>& G_t, FockSigma<ztensor<4>, ztensor<5>>& FS_t,
+  void commutator_t(const grids::transformer_t& ft, ztensor<5>& C_t, ztensor<5>& G_t, fock_sigma<ztensor<4>, ztensor<5>>& FS_t,
                     double mu, const ztensor<4>& H0, const ztensor<4>& S) {
     size_t       nao           = G_t.shape()[4];
     MPI_Datatype dt_matrix     = utils::create_matrix_datatype<std::complex<double>>(nao * nao);

--- a/src/green/sc/vector_space_fock_sigma.h
+++ b/src/green/sc/vector_space_fock_sigma.h
@@ -159,6 +159,9 @@ namespace green::opt {
      * @param vec - vector to be added into a vector space
      */
     void add(const fock_sigma<S1, St>& vec) {
+      // we don't have automatic purge therefore we have to make sure that vector space
+      // does not grow above maximum capacity
+      if(_m_size == _diis_size) throw sc::sc_diis_vsp_error("VSpace is at it's maximum capacity");
       if (!utils::context.global_rank) write_to_dbase(vec);
       MPI_Barrier(utils::context.global);
       _m_size++;

--- a/test/sc_test.cpp
+++ b/test/sc_test.cpp
@@ -18,6 +18,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
+#include <green/sc/cyclic_vector_space_fock_sigma.h>
 #include <green/sc/sc_loop.h>
 
 #include <catch2/catch_session.hpp>
@@ -438,12 +439,13 @@ TEST_CASE("Mixing") {
   }
 }
 
-TEST_CASE("FockSigmaVectorSpace") {
+template <template <typename, typename> typename T>
+void test_vector_space() {
   using S1          = green::sc::ztensor<4>;
   using St          = green::utils::shared_object<green::sc::ztensor<5>>;
-  using vec_t       = green::opt::FockSigma<S1, St>;
+  using vec_t       = green::opt::fock_sigma<S1, St>;
   using problem_t   = green::opt::shared_optimization_problem<vec_t>;
-  using vec_space_t = green::opt::VSpaceFockSigma<S1, St>;
+  using vec_space_t = T<S1, St>;
 
   S1 s1_0(1, 2, 3, 3);
   St s_t_0(10, 1, 2, 3, 3);
@@ -498,6 +500,10 @@ TEST_CASE("FockSigmaVectorSpace") {
   x_vsp.reset();
   std::filesystem::remove(diis_file);
 }
+
+TEST_CASE("FockSigmaVectorSpace") { test_vector_space<green::opt::vector_space_fock_sigma>(); }
+
+TEST_CASE("CyclicFockSigmaVectorSpace") { test_vector_space<green::opt::cyclic_vector_space_fock_sigma>(); }
 
 int main(int argc, char** argv) {
   MPI_Init(&argc, &argv);

--- a/test/sc_test.cpp
+++ b/test/sc_test.cpp
@@ -481,6 +481,10 @@ void test_vector_space() {
     REQUIRE(x_vsp.size() == ((i < diis_size) ? i + 1 : diis_size));
     auto& tmp  = x_vsp.get(0);
     auto& fock = tmp.get_fock();
+    x_vsp.get(0, *vec_i);
+    auto& fock_i = vec_i->get_fock();
+    REQUIRE(std::equal(fock.begin(), fock.end(), fock_i.begin(),
+                       [](const std::complex<double>& x, const std::complex<double>& y) { return std::abs(x - y) < 1e-10; }));
     if (i < diis_size)
       REQUIRE(std::equal(fock.begin(), fock.end(), s1_0.begin(),
                          [](const std::complex<double>& x, const std::complex<double>& y) { return std::abs(x - y) < 1e-10; }));

--- a/test/sc_test.cpp
+++ b/test/sc_test.cpp
@@ -288,7 +288,8 @@ TEST_CASE("Mixing") {
     auto        p          = green::params::params("DESCR");
     std::string res_file_1 = random_name();
     std::string args_1 =
-        "test --restart 0 --itermax 4 --E_thr 1e-13 --mixing_type=SIGMA_DAMPING --damping 0.5 --results_file=" + res_file_1;
+        "test  --verbose 1 --restart 0 --itermax 4 --E_thr 1e-13 --mixing_type=SIGMA_DAMPING --damping 0.5 --results_file=" +
+        res_file_1;
     green::sc::define_parameters(p);
     p.parse(args_1);
     green::h5pp::archive ar(res_file_1, "w");
@@ -313,7 +314,7 @@ TEST_CASE("Mixing") {
     std::string mix_file_1 = random_name();
     std::string args_1 =
         "test --BETA 100 --grid_file ir/1e4.h5 --restart 0 --itermax 4 --E_thr 1e-13 --mixing_type=DIIS --diis_start 1 "s +
-        "--damping 0.5 --results_file="s + res_file_1 + " --diis_file " + mix_file_1;
+        "--damping 0.5 --results_file="s + res_file_1 + " --verbose 1 --diis_file " + mix_file_1;
     green::sc::define_parameters(p);
     green::grids::define_parameters(p);
     p.parse(args_1);
@@ -381,7 +382,7 @@ TEST_CASE("Mixing") {
     std::string mix_file_1 = random_name();
     std::string args_1 =
         "test --BETA 100 --grid_file ir/1e4.h5 --restart 0 --itermax 4 --E_thr 1e-13 --mixing_type=CDIIS --diis_start 1 "s +
-        "--damping 0.5 --results_file="s + res_file_1 + " --diis_file " + mix_file_1;
+        "--damping 0.5 --verbose 1 --results_file="s + res_file_1 + " --diis_file " + mix_file_1;
     green::sc::define_parameters(p);
     green::grids::define_parameters(p);
     p.parse(args_1);


### PR DESCRIPTION
Purge implementation through move preserving the IO count of the cyclic implementation. The cyclic functionality is preserved; the corresponding functions are labeled _cyclic.
The new functionality is needed for the implementation of more advanced subspace algorithms.