### PR TITLE
Fix description of damping in README and help string

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following parameters have to be specified:
 
 - `itermax` - maximum number of iterations to run
 - `mixing_type` - type of mixing between iterations
-- `damping` - how mach of a previous iteration to be mixed with the current iteration results
+- `damping` - how mach of a previous iteration to be mixed with the current iteration results (`1`: no damping, `0`: full damping)
 - `results_file` - file to store results at each iteration
 - `restart` - checkpointing
 - `threshold` - convergence threshold, iterations will be stopped if convergence creteria is smaller than `threshold`.

--- a/src/green/sc/common_defs.h
+++ b/src/green/sc/common_defs.h
@@ -65,8 +65,8 @@ namespace green::sc {
   inline void define_parameters(params::params& p) {
     p.define<mixing_type>("mixing_type", "Type of iteration convergence mixing. We use no mixing by default", SIGMA_DAMPING);
     p.define<double>("damping",
-                     "Simple mixing paramters between current ad previous iteration. Should be between 0 and 1: 0 - no damping, "
-                     "1 - full damping.",
+                     "Simple mixing paramters between current ad previous iteration. Should be between 0 and 1: 1 - no damping, "
+                     "0 - full damping.",
                      0.7);
     p.define<int>("diis_start", "Iteration number when we start using DIIS", 2);
     p.define<int>("diis_size", "Size of DIIS subspace", 3);

--- a/src/green/sc/common_defs.h
+++ b/src/green/sc/common_defs.h
@@ -65,8 +65,8 @@ namespace green::sc {
   inline void define_parameters(params::params& p) {
     p.define<mixing_type>("mixing_type", "Type of iteration convergence mixing. We use no mixing by default", SIGMA_DAMPING);
     p.define<double>("damping",
-                     "Simple mixing paramters between current ad previous iteration. Should be between 0 and 1: 1 - no damping, "
-                     "0 - full damping.",
+                     "Simple mixing paramters between current ad previous iteration. Should be between 0 and 1: 1 - no damping (direct Roothaan steps), "
+                     "0 - full damping (and no update).",
                      0.7);
     p.define<int>("diis_start", "Iteration number when we start using DIIS", 2);
     p.define<int>("diis_size", "Size of DIIS subspace", 3);

--- a/src/green/sc/common_utils.h
+++ b/src/green/sc/common_utils.h
@@ -70,7 +70,7 @@ namespace green::sc::internal {
    *
    * @tparam T - type of object
    * @param obj_n - result for current iteration
-   * @param obj_n_1 - result for previous iteration iteration
+   * @param obj_n_1 - result for previous iteration
    * @param damping - mixing parameter
    */
   template <typename T>


### PR DESCRIPTION
This PR should make the definition of damping fairly consistent among all the Green-Phys codes and documentations.