### PR TITLE
renaming damping into mixing_weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following parameters have to be specified:
 
 - `itermax` - maximum number of iterations to run
 - `mixing_type` - type of mixing between iterations
-- `damping` - how mach of a previous iteration to be mixed with the current iteration results (`1`: no damping, `0`: full damping)
+- `mixing_weight` - how much of a previous iteration to be mixed with the current iteration results (`1`: no contribution from previous iteration, `0`: no contribution from current iteration)
 - `results_file` - file to store results at each iteration
 - `restart` - checkpointing
 - `threshold` - convergence threshold, iterations will be stopped if convergence creteria is smaller than `threshold`.

--- a/src/green/sc/common_defs.h
+++ b/src/green/sc/common_defs.h
@@ -27,7 +27,7 @@ namespace green::sc {
   /**
    *
    */
-  enum mixing_type { NO_MIXING, G_DAMPING, SIGMA_DAMPING, DIIS, CDIIS };
+  enum mixing_type { NO_MIXING, G_MIXING, SIGMA_MIXING, DIIS, CDIIS };
   // Tensor types
   template <typename prec, size_t Dim>
   using tensor = green::ndarray::ndarray<prec, Dim>;
@@ -63,11 +63,12 @@ namespace green::sc {
   }
 
   inline void define_parameters(params::params& p) {
-    p.define<mixing_type>("mixing_type", "Type of iteration convergence mixing. We use no mixing by default", SIGMA_DAMPING);
-    p.define<double>("damping",
-                     "Simple mixing paramters between current ad previous iteration. Should be between 0 and 1: 1 - no damping (direct Roothaan steps), "
-                     "0 - full damping (and no update).",
+    p.define<mixing_type>("mixing_type", "Type of iteration convergence mixing. We use no mixing by default", SIGMA_MIXING);
+    p.define<double>("mixing_weight,mixing_alpha",
+                     "Simple mixing parameters between current ad previous iteration: X_n = mixing_weight X_n + (1-mixing_weight) X_{n-1}."
+                     " Should be between 0 and 2.",
                      0.7);
+    p.define<double>("damping", "This parameter exists for legacy purpose and should never be set. If this parameter is set exception will be thrown.", 0);
     p.define<int>("diis_start", "Iteration number when we start using DIIS", 2);
     p.define<int>("diis_size", "Size of DIIS subspace", 3);
     p.define<std::string>("diis_file", "File to store results", "diis.h5");

--- a/src/green/sc/common_defs.h
+++ b/src/green/sc/common_defs.h
@@ -63,7 +63,7 @@ namespace green::sc {
   }
 
   inline void define_parameters(params::params& p) {
-    p.define<mixing_type>("mixing_type", "Type of iteration convergence mixing. We use no mixing by default", SIGMA_MIXING);
+    p.define<mixing_type>("mixing_type", "Type of iteration convergence mixing. We use self-energy mixing by default", SIGMA_MIXING);
     p.define<double>("mixing_weight,mixing_alpha",
                      "Simple mixing parameters between current ad previous iteration: X_n = mixing_weight X_n + (1-mixing_weight) X_{n-1}."
                      " Should be between 0 and 2.",

--- a/src/green/sc/common_defs.h
+++ b/src/green/sc/common_defs.h
@@ -68,7 +68,7 @@ namespace green::sc {
                      "Simple mixing parameters between current ad previous iteration: X_n = mixing_weight X_n + (1-mixing_weight) X_{n-1}."
                      " Should be between 0 and 2.",
                      0.7);
-    p.define<double>("damping", "This parameter exists for legacy purpose and should never be set. If this parameter is set exception will be thrown.", 0);
+    p.define<double>("damping", "This parameter exists for legacy purpose and should never be set. If this parameter is set exception will be thrown.");
     p.define<int>("diis_start", "Iteration number when we start using DIIS", 2);
     p.define<int>("diis_size", "Size of DIIS subspace", 3);
     p.define<std::string>("diis_file", "File to store results", "diis.h5");

--- a/src/green/sc/common_utils.h
+++ b/src/green/sc/common_utils.h
@@ -66,17 +66,17 @@ namespace green::sc::internal {
 
   /**
    * Mix data of current (obj_n) and previous (obj_n_1) iterations
-   * obj_n = obj_n * damping + obj_n_1 * (1 - damping)
+   * obj_n = obj_n * mixing_weight + obj_n_1 * (1 - mixing_weight)
    *
    * @tparam T - type of object
    * @param obj_n - result for current iteration
    * @param obj_n_1 - result for previous iteration
-   * @param damping - mixing parameter
+   * @param mixing_weight - mixing parameter
    */
   template <typename T>
-  void update(T& obj_n, T& obj_n_1, double damping) {
-    obj_n *= damping;
-    obj_n += obj_n_1 * (1.0 - damping);
+  void update(T& obj_n, T& obj_n_1, double mixing_weight) {
+    obj_n *= mixing_weight;
+    obj_n += obj_n_1 * (1.0 - mixing_weight);
   }
 
   template <typename T, size_t N, typename C>
@@ -187,18 +187,18 @@ namespace green::sc::internal {
   /**
    * Shared memory version of update function
    * Mix data of current (obj_n) and previous (obj_n_1) iterations
-   * obj_n = obj_n * damping + obj_n_1 * (1 - damping)
+   * obj_n = obj_n * mixing_weight + obj_n_1 * (1 - mixing_weight)
    *
    * @tparam T - type of object
    * @param obj_n - result for current iteration
    * @param obj_n_1 - result for previous iteration iteration
-   * @param damping - mixing parameter
+   * @param mixing_weight - mixing parameter
    */
-  inline void update(utils::shared_object<ztensor<5>>& obj_n, utils::shared_object<ztensor<5>>& obj_n_1, double damping) {
+  inline void update(utils::shared_object<ztensor<5>>& obj_n, utils::shared_object<ztensor<5>>& obj_n_1, double mixing_weight) {
     obj_n.fence();
     if (!utils::context.node_rank) {
-      obj_n.object() *= damping;
-      obj_n.object() += obj_n_1.object() * (1.0 - damping);
+      obj_n.object() *= mixing_weight;
+      obj_n.object() += obj_n_1.object() * (1.0 - mixing_weight);
     }
     obj_n.fence();
   }

--- a/src/green/sc/except.h
+++ b/src/green/sc/except.h
@@ -25,9 +25,9 @@
 
 namespace green::sc {
 
-  class sc_incorrect_damping_error : std::runtime_error {
+  class sc_incorrect_mixing_error : std::runtime_error {
   public:
-    explicit sc_incorrect_damping_error(const std::string& what) : std::runtime_error(what) {}
+    explicit sc_incorrect_mixing_error(const std::string& what) : std::runtime_error(what) {}
   };
 
   class sc_diis_vsp_error : std::runtime_error {

--- a/src/green/sc/mixing.h
+++ b/src/green/sc/mixing.h
@@ -263,7 +263,7 @@ namespace green::sc {
   class mixing_strategy {
   public:
     explicit mixing_strategy(const params::params& p) : _mixing(nullptr), _verbose(p["verbose"]) {
-      if (p["damping"].is_set()) {
+      if (p.is_set("damping")) {
         throw sc_incorrect_mixing_error(
             "Parameter `--damping` was provided, please use `--mixing_weight` parameter instead. "
             "We use the following definition: X_n = a X_n + (1-a) X_{n-1}, where `a` is set by `--mixing_weight`.");

--- a/src/green/sc/mixing.h
+++ b/src/green/sc/mixing.h
@@ -82,11 +82,17 @@ namespace green::sc {
    * @tparam St
    */
   template <typename G, typename S1, typename St>
-  class g_damping : public base_mixing<G, S1, St> {
+  class g_mixing : public base_mixing<G, S1, St> {
   public:
-    g_damping(double d, const std::string& res) : _damping(d), _results_file(res) {
-      if (d <= 0.0 || d > 1.0) {
-        throw sc_incorrect_damping_error("Damping should be in (0,1] interval");
+    g_mixing(double m, const std::string& res) : _mixing_weight(m), _results_file(res) {
+      if (m <= 0.0 || m >= 2.0) {
+        throw sc_incorrect_mixing_error("Mixing should be in (0,2) interval");
+      }
+      if (m > 1) {
+        if (utils::context.global_rank == 0)
+          std::cout << "Mixing parameter is set to be bigger than one, in the over-relaxation regime convergence potentially can "
+                       "be unstable."
+                    << std::endl;
       }
     }
     void update(size_t iter, double, const S1&, const S1&, G& g, S1&, St&) override {
@@ -95,27 +101,33 @@ namespace green::sc {
       }
       G g_tmp(internal::init_data(g));
       internal::read_data(g_tmp, _results_file, "iter" + std::to_string(iter - 1) + "/G_tau/data");
-      internal::update(g, g_tmp, _damping);
+      internal::update(g, g_tmp, _mixing_weight);
       internal::cleanup_data(g_tmp);
     };
 
     void print_name() override {
       if (utils::context.global_rank == 0)
-        std::cout << "Green's function mixing strategy will be applied: " << _damping << "*G_new + " << (1 - _damping) << "*G_old"
-                  << std::endl;
+        std::cout << "Green's function mixing strategy will be applied: " << _mixing_weight << "*G_new + " << (1 - _mixing_weight)
+                  << "*G_old" << std::endl;
     }
 
   private:
-    double      _damping;
+    double      _mixing_weight;
     std::string _results_file;
   };
 
   template <typename G, typename S1, typename St>
-  class sigma_damping : public base_mixing<G, S1, St> {
+  class sigma_mixing : public base_mixing<G, S1, St> {
   public:
-    sigma_damping(double d, const std::string& res) : _damping(d), _results_file(res) {
-      if (d <= 0.0 || d > 1.0) {
-        throw sc_incorrect_damping_error("Damping should be in (0,1] interval");
+    sigma_mixing(double m, const std::string& res) : _mixing_weight(m), _results_file(res) {
+      if (m <= 0.0 || m >= 2.0) {
+        throw sc_incorrect_mixing_error("Mixing should be in (0,2) interval");
+      }
+      if (m > 1) {
+        if (utils::context.global_rank == 0)
+          std::cout << "Mixing parameter is set to be bigger than one, in the over-relaxation regime convergence potentially can "
+                       "be unstable."
+                    << std::endl;
       }
     }
     void update(size_t iter, double, const S1&, const S1&, G&, S1& s1, St& s_t) override {
@@ -124,22 +136,22 @@ namespace green::sc {
       }
       St st_tmp(internal::init_data(s_t));
       internal::read_data(st_tmp, _results_file, "iter" + std::to_string(iter - 1) + "/Selfenergy/data");
-      internal::update(s_t, st_tmp, _damping);
+      internal::update(s_t, st_tmp, _mixing_weight);
       internal::cleanup_data(st_tmp);
       S1 s1_tmp(internal::init_data(s1));
       internal::read_data(s1_tmp, _results_file, "iter" + std::to_string(iter - 1) + "/Sigma1");
-      internal::update(s1, s1_tmp, _damping);
+      internal::update(s1, s1_tmp, _mixing_weight);
       internal::cleanup_data(s1_tmp);
     };
 
     void print_name() override {
       if (utils::context.global_rank == 0)
-        std::cout << "Self-energy mixing strategy will be applied: " << _damping << "*Sigma_new + " << (1 - _damping)
+        std::cout << "Self-energy mixing strategy will be applied: " << _mixing_weight << "*Sigma_new + " << (1 - _mixing_weight)
                   << "*Sigma_old" << std::endl;
     }
 
   private:
-    double      _damping;
+    double      _mixing_weight;
     std::string _results_file;
   };
 
@@ -150,7 +162,7 @@ namespace green::sc {
    * @tparam St
    */
   template <typename G, typename S1, typename St>
-  class diis : public sigma_damping<G, S1, St> {
+  class diis : public sigma_mixing<G, S1, St> {
     using vec_t       = opt::fock_sigma<S1, St>;
     using problem_t   = opt::shared_optimization_problem<vec_t>;
     using vec_space_t = opt::vector_space_fock_sigma<S1, St>;
@@ -158,7 +170,7 @@ namespace green::sc {
 
   public:
     diis(const params::params& p, bool commutator) :
-        sigma_damping<G, S1, St>(p["damping"], p["results_file"]), _damping(p["damping"]), _results_file(p["results_file"]),
+        sigma_mixing<G, S1, St>(p["mixing_weight"], p["results_file"]), _mixing(p["mixing_weight"]), _results_file(p["results_file"]),
         _diis_file(p["diis_file"]), _diis_start(p["diis_start"]), _diis_size(p["diis_size"]),
         _diis(_diis_start, _diis_size, p["verbose"]), _x_vsp(_diis_file, _diis_size + 1),
         _res_vsp(_diis_file, _diis_size, "residuals"), _ft(p), _commutator(commutator) {
@@ -208,7 +220,7 @@ namespace green::sc {
         return;
       }
       if (iter <= _diis_start) {
-        sigma_damping<G, S1, St>::update(iter, mu, h0, ovlp, g, s1, s_t);
+        sigma_mixing<G, S1, St>::update(iter, mu, h0, ovlp, g, s1, s_t);
         internal::assign(problem.x().get_fock(), s1);
         internal::assign(problem.x().get_sigma(), s_t);
       }
@@ -227,7 +239,7 @@ namespace green::sc {
     };
 
   private:
-    double               _damping;
+    double               _mixing;
     std::string          _results_file;
     std::string          _diis_file;
     size_t               _diis_start;
@@ -251,15 +263,20 @@ namespace green::sc {
   class mixing_strategy {
   public:
     explicit mixing_strategy(const params::params& p) : _mixing(nullptr), _verbose(p["verbose"]) {
+      if (p["damping"].is_set()) {
+        throw sc_incorrect_mixing_error(
+            "Parameter `--damping` was provided, please use `--mixing_weight` parameter instead. "
+            "We use the following definition: X_n = a X_n + (1-a) X_{n-1}, where `a` is set by `--mixing_weight`.");
+      }
       switch (p["mixing_type"].as<mixing_type>()) {
         case NO_MIXING:
           _mixing = std::make_unique<no_mixing<G, S1, St>>();
           break;
-        case G_DAMPING:
-          _mixing = std::make_unique<g_damping<G, S1, St>>(p["damping"], p["results_file"]);
+        case G_MIXING:
+          _mixing = std::make_unique<g_mixing<G, S1, St>>(p["mixing_weight"], p["results_file"]);
           break;
-        case SIGMA_DAMPING:
-          _mixing = std::make_unique<sigma_damping<G, S1, St>>(p["damping"], p["results_file"]);
+        case SIGMA_MIXING:
+          _mixing = std::make_unique<sigma_mixing<G, S1, St>>(p["mixing_weight"], p["results_file"]);
           break;
         case DIIS:
           _mixing = std::make_unique<diis<G, S1, St>>(p, false);

--- a/src/green/sc/sc_loop.h
+++ b/src/green/sc/sc_loop.h
@@ -66,7 +66,7 @@ namespace green::sc {
     bool _restart;
     // Dyson Equation solver
     DysonSolver _dyson_solver;
-    // DIIS or simple damping object
+    // DIIS or simple mixing object
     mixing_strategy<G, S1, St> _mix;
     // MPI
     utils::mpi_context _context;

--- a/test/sc_test.cpp
+++ b/test/sc_test.cpp
@@ -197,8 +197,12 @@ TEST_CASE("Self-consistency") {
   SECTION("Solve with mixing") {
     solve_with_mixing("G_MIXING", "0.8");
     solve_with_mixing("SIGMA_MIXING", "0.8");
+    solve_with_mixing("G_MIXING", "1.1");
+    solve_with_mixing("SIGMA_MIXING", "1.1");
     REQUIRE_THROWS_AS(solve_with_mixing("G_MIXING", "2.8"), green::sc::sc_incorrect_mixing_error);
     REQUIRE_THROWS_AS(solve_with_mixing("SIGMA_MIXING", "2.8"), green::sc::sc_incorrect_mixing_error);
+    REQUIRE_THROWS_AS(solve_with_mixing("G_MIXING", "-0.1"), green::sc::sc_incorrect_mixing_error);
+    REQUIRE_THROWS_AS(solve_with_mixing("SIGMA_MIXING", "0.0"), green::sc::sc_incorrect_mixing_error);
   }
 
   SECTION("Restart") {


### PR DESCRIPTION
With this update we rename `damping` to `mixing_weight` and throw an exception if `damping` is used.